### PR TITLE
Update SetupCommand.php to use `__get('description')` instead of `getDescription()`

### DIFF
--- a/src/SetupCommand.php
+++ b/src/SetupCommand.php
@@ -68,7 +68,7 @@ class SetupCommand extends Command
             // DESCRIPTION
             $this->_print('------------------------------');
             $this->_lineBreak();
-            $this->getDescription();
+            $this->__get('description');
             $this->_lineBreak();
             // End
             $this->_print('------------------------------');


### PR DESCRIPTION
This resolve the issue #1 I setup by replacing the invalid `getDescription` method to use the magic `__get()` function for the description.