### PR TITLE
Update the checks for traversal directories (. & ..) to account for full paths

### DIFF
--- a/src/Base/BaseCommand.php
+++ b/src/Base/BaseCommand.php
@@ -66,7 +66,7 @@ class BaseCommand extends Command
      */
     protected function replaceInFile($needle, $replace, $filename)
     {
-        if ($filename == '.' || $filename == '..') return;
+        if (substr($filename,-1) === '.') return;
         file_put_contents( 
             $filename, 
             preg_replace(


### PR DESCRIPTION
This fixes issues #3 

I've replaced the previous check;
`if ($filename == '.' || $filename == '..') return;`
With;
`if (substr($filename,-1) === '.') return;`

This accounts for when the traversal directories are called with the full path like;
`file_put_contents(/path/to/plugin/app/Models/.)`

The new check checks the last character isn't a period to account for both cases.