### PR TITLE
Update `$config` references to `$this->config` so the Controllers path can be used

### DIFF
--- a/src/SetNameCommand.php
+++ b/src/SetNameCommand.php
@@ -77,16 +77,16 @@ class SetNameCommand extends Command
             );
         }
 
-        foreach (scandir($config['paths']['controllers']) as $filename) {
+        foreach (scandir($this->config['paths']['controllers']) as $filename) {
             $this->replaceInFile( 
                 'namespace ' . $currentname,
                 'namespace ' . $name,
-                $config['paths']['controllers'] . $filename
+                $this->config['paths']['controllers'] . $filename
             );
             $this->replaceInFile( 
                 'use ' . $currentname,
                 'use ' . $name,
-                $config['paths']['controllers'] . $filename
+                $this->config['paths']['controllers'] . $filename
             );
         }
 


### PR DESCRIPTION
The code setting up the controllers used $config and failed with warnings. Updating them to use `$this->config` resolves the issue and fixes #5