### PR TITLE
Fix the TextDomain setup when Type is plugin

### DIFF
--- a/src/SetNameCommand.php
+++ b/src/SetNameCommand.php
@@ -62,6 +62,7 @@ class SetNameCommand extends Command
         $currentname = $this->config['namespace'];
 
         $this->replaceInFile($currentname, $name, $this->configFilename);
+        $this->config = include $this->configFilename;
         if (file_exists($this->rootPath . '/app/Main.php'))
             $this->replaceInFile( 
                 'namespace ' . $currentname,

--- a/src/SetupCommand.php
+++ b/src/SetupCommand.php
@@ -114,6 +114,7 @@ class SetupCommand extends Command
         // Type handling
         $currentType = $this->config['type'];
         $this->replaceInFile('\''.$currentType.'\'', '\''.$type.'\'', $this->configFilename);
+        $this->config = include $this->configFilename;
 
         $this->_print('Type set!');
         $this->_lineBreak();

--- a/src/Traits/SetTextDomainTrait.php
+++ b/src/Traits/SetTextDomainTrait.php
@@ -29,6 +29,7 @@ trait SetTextDomainTrait
             $currentDomain = $this->config['localize']['textdomain'];
             // Replace in config file
             $this->replaceInFile('\''.$currentDomain.'\'', '\''.$domain.'\'', $this->configFilename);
+            $this->config = include $this->configFilename;
             // Replace in package.json
             $packageJson = json_decode(file_get_contents($this->rootPath.'/package.json'));
             $this->replaceInFile(

--- a/src/Traits/SetVersionTrait.php
+++ b/src/Traits/SetVersionTrait.php
@@ -29,6 +29,7 @@ trait SetVersionTrait
             $currentVersion = $this->config['version'];
             // Replace in config file
             $this->replaceInFile($currentVersion, $version, $this->configFilename);
+            $this->config = include $this->configFilename;
             // Replace in package.json
             $packageJson = json_decode(file_get_contents($this->rootPath.'/package.json'));
             $this->replaceInFile(


### PR DESCRIPTION
Update config object after each replaceInFile call to update the configFile. This fixes an issue where you specify plugin as the type but then the TextDomain setup is using the outdated config object which hold the default of theme causing an empty style.css to be injected and failed to update the plugin.php. By updating the config object after each config file update to ensure it's storing the latest config settings throughout the setup command.