### PR TITLE
Fix the Add Command

### DIFF
--- a/src/Visitors/AddMethodCallVisitor.php
+++ b/src/Visitors/AddMethodCallVisitor.php
@@ -4,6 +4,7 @@ namespace WPMVC\Commands\Visitors;
 
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
@@ -79,7 +80,7 @@ class AddMethodCallVisitor extends NodeVisitorAbstract
      */
     public function leaveNode(Node $node)
     {
-        if ($node instanceof ClassMethod && $node->name === $this->nodeName) {
+        if ($node instanceof ClassMethod && $node->name == $this->nodeName) {
             // Build arguments.
             $args = [];
             foreach ($this->args as $arg) {
@@ -99,10 +100,12 @@ class AddMethodCallVisitor extends NodeVisitorAbstract
             ]);
             $node->stmts[] = $nop;
             // ADD statement
-            $node->stmts[] = new MethodCall(
-                empty($this->variable) ? null : new Variable($this->variable),
-                $this->methodName,
-                $args
+            $node->stmts[] = new Expression(
+                new MethodCall(
+                    empty($this->variable) ? null : new Variable($this->variable),
+                    $this->methodName,
+                    $args
+                )
             );
         }
     }


### PR DESCRIPTION
Update AddMethodCallVisitor.php to update the strict conditional to make it non-strict as $node->name is an object and not a string. Also update the MethodCall to wrap in an Expression in order to append the semi-colon.


Note: The other solution for dealing with the fact $node->name is an object and as such failing the strict conditional is calling $node->name.toString() instead. I didn't bother with that and just switched it to non-strict as the $node->name object has the __toString() magic function so will evaluate to a string.