### PR TITLE
Update Setup Command to output Description

### DIFF
--- a/src/SetupCommand.php
+++ b/src/SetupCommand.php
@@ -78,7 +78,7 @@ class SetupCommand extends Command
             // DESCRIPTION
             $this->_print('------------------------------');
             $this->_lineBreak();
-            $this->description;
+            $this->_print($this->description);
             $this->_lineBreak();
             // End
             $this->_print('------------------------------');


### PR DESCRIPTION
The change to the setup command for the description used the right variable but didn't print it so we ended up with an empty space between two of the horizontal rules. This patch wraps the description in a print call to output it to the console.