### PR TITLE
Update Setup Command to update $namespace variable

### DIFF
--- a/src/SetupCommand.php
+++ b/src/SetupCommand.php
@@ -57,10 +57,8 @@ class SetupCommand extends Command
             $this->_print('Enter your project\'s namespace (example: MyProject):');
             $this->_lineBreak();
             $namespace = $this->listener->getInput();
-            $command->setName(empty($namespace)
-                ? 'MyApp'
-                : str_replace(' ', '', ucwords($namespace))
-            );
+            $namespace = empty($namespace) ? 'MyApp' : str_replace(' ', '', ucwords($namespace));
+            $command->setName($namespace);
             // TYPE
             $this->_print('------------------------------');
             $this->_lineBreak();


### PR DESCRIPTION
As the Setup command runs a str_replace and ucwords on the inputted $namespace it's often different than what's input. The output later in the setup then can be misleading as in some cases it'll have changed during the process to strip spaces and make first words uppercase.
This patch updates the $namespace variable so when it's output later the user see what the actual project namespace is.