### PR TITLE
Update createView call to drop the second param which is meant for $template

### DIFF
--- a/src/AddCommand.php
+++ b/src/AddCommand.php
@@ -68,7 +68,7 @@ class AddCommand extends Command
         }
         switch ($vc[0]) {
             case 'view':
-                $this->createView($vc[1]);
+                $this->createView($vc[1], isset($args[4]) ? $args[4] : 'view.php');
                 break;
             default:
                 $this->createController($vc[0]);

--- a/src/CreateCommand.php
+++ b/src/CreateCommand.php
@@ -56,7 +56,7 @@ class CreateCommand extends Command
             case 'view':
                 if (!isset($object[1]) || empty($object[1]))
                     throw new NoticeException('Command "'.$this->key.'": View key name is missing.');
-                $this->createView($object[1], $args);
+                $this->createView($object[1]);
                 break;
             case 'controller':
                 if (!isset($object[1]) || empty($object[1]))

--- a/src/CreateCommand.php
+++ b/src/CreateCommand.php
@@ -56,7 +56,7 @@ class CreateCommand extends Command
             case 'view':
                 if (!isset($object[1]) || empty($object[1]))
                     throw new NoticeException('Command "'.$this->key.'": View key name is missing.');
-                $this->createView($object[1]);
+                $this->createView($object[1], isset($args[3]) ? $args[3] : 'view.php');
                 break;
             case 'controller':
                 if (!isset($object[1]) || empty($object[1]))


### PR DESCRIPTION
This PR updates the Create Command for creating views so that it uses the template.
The existing call to createView passed $args as a second param, being empty and the createView expecting it to reference the template file instead the view is created empty.
This update drops the $args so createView just uses the default View Template.