### PR TITLE
Update exception to include all model objects

### DIFF
--- a/src/CreateCommand.php
+++ b/src/CreateCommand.php
@@ -48,7 +48,7 @@ class CreateCommand extends Command
     public function call($args = [])
     {
         if (count($args) == 0 || empty($args[2]))
-            throw new NoticeException('Command "'.$this->key.'": Expecting an object to create (model|view|controller).');
+            throw new NoticeException('Command "'.$this->key.'": Expecting an object to create (view|controller|model|postmodel|optionmodel|usermodel|categorymodel|termmodel).');
 
         $object = explode(':', $args[2]);
 


### PR DESCRIPTION
When you pipe an invalid object to the create command it only lists `model|view|controller`. THis updates it to also list postmodel|optionmodel|usermodel|categorymodel|termmodel.

NOTE: The termmodel object currently isn't documented here - https://www.wordpress-mvc.com/v1/ayuco/