### PR TITLE
Expand Create Controller command to support multiple methods

### DIFF
--- a/src/CreateCommand.php
+++ b/src/CreateCommand.php
@@ -63,9 +63,10 @@ class CreateCommand extends Command
                     throw new NoticeException('Command "'.$this->key.'": Controller definition is missing.');
                 $controller = explode('@', $object[1]);
                 $this->createController($controller[0], $args);
-                // Create method
+                // Create methods
                 if (count($controller) > 1)
-                    $this->createControllerMethod($controller[0], $controller[1]);
+                    foreach (array_slice($controller, 1) as $controller_method)
+                        $this->createControllerMethod($controller[0], $controller_method);
                 break;
             case 'model':
             case 'postmodel':


### PR DESCRIPTION
This little patch takes advantage of the existing '@' delimiter to allow multiple methods to be created through the create controller command.

Example Usage;
`php ayuco create controller:ControllerName@FirstMethod@SecondMethod@etcMethod`
This call would create the ControllerName.php file and inject 3 method calls for the additional items added after the '@' delimiter