### PR TITLE
Expand CSS creation to support template

### DIFF
--- a/src/CreateCommand.php
+++ b/src/CreateCommand.php
@@ -104,7 +104,7 @@ class CreateCommand extends Command
             case 'css':
                 if (!isset($object[1]) || empty($object[1]))
                     throw new NoticeException('Command "'.$this->key.'": CSS filename is missing.');
-                $this->createAsset('css', $object[1]);
+                $this->createAsset('css', $object[1], ['template' => isset($args[3]) ? $args[3] : 'asset']);
                 break;
             case 'sass':
                 if (!isset($object[1]) || empty($object[1]))


### PR DESCRIPTION
The css command runs through the same switch statement in createAsset and as such supports use of a template file instead of just the asset.css template. This minor change updates the create css command to support an additional param for the template name.

Note: This will require a docs update here;
https://www.wordpress-mvc.com/v1/ayuco/
*Also note maybe instead of '(1) Optional script type' for the js command have it state 'Optional template name.' Then match the css one.

Also would be good to update the expanded commands documentation for Scripts and Styles;
Scripts - wordpress-mvc.com/v1/assets/scripts/
Styles - wordpress-mvc.com/v1/assets/styles/
*In my opinion it's less confusing to use {template} instead of {type} as we're specifying a template file and that doesn't always have to be just asset and jquery as the user can expand on the templates available. Initially when I read type I was thinking about it like script type `<script type="application/javascript">`

