### PR TITLE
Minor updates to the Setup and Set Author commands.

### DIFF
--- a/src/SetCommand.php
+++ b/src/SetCommand.php
@@ -49,8 +49,8 @@ class SetCommand extends Command
         $object = explode(':', $args[2]);
 
         // Validations
-        if (!in_array($object[0], ['version','domain']))
-            throw new NoticeException('Command "'.$this->key.'": Invalid setting. Expecting (version|domain).');
+        if (!in_array($object[0], ['version','domain','author']))
+            throw new NoticeException('Command "'.$this->key.'": Invalid setting. Expecting (version|domain|author).');
 
         switch ($object[0]) {
             case 'version':

--- a/src/SetupCommand.php
+++ b/src/SetupCommand.php
@@ -46,7 +46,6 @@ class SetupCommand extends Command
             throw new NoticeException('SetupCommand: "set" command is not registered in ayuco.');
             
         try {
-            $this->_lineBreak();
             $this->_print('------------------------------');
             $this->_lineBreak();
             $this->_print('WordPress MVC (AYUCO) Setup');
@@ -76,6 +75,7 @@ class SetupCommand extends Command
             $setCommand->setTextDomain(empty($domain) ? 'my-app' : $domain);
             // AUTHOR
             $setCommand->setAuthor();
+            $this->config = include $this->configFilename;
             // DESCRIPTION
             $this->_print('------------------------------');
             $this->_lineBreak();
@@ -87,6 +87,8 @@ class SetupCommand extends Command
             $this->_print('Your project\'s namespace is "%s"', $namespace);
             $this->_lineBreak();
             $this->_print('Your project\'s text domain is "%s"', $domain);
+            $this->_lineBreak();
+            $this->_print('Your project\'s author is "%s"', $this->config['author']);
             $this->_lineBreak();
             $this->_print('Setup completed!');
             $this->_lineBreak();

--- a/src/Traits/SetAuthorTrait.php
+++ b/src/Traits/SetAuthorTrait.php
@@ -25,24 +25,23 @@ trait SetAuthorTrait
         try {
             $input = ['name' => null, 'contact' => null];
             // Ask for author information
-            $this->_lineBreak();
             $this->_print('------------------------------');
             $this->_lineBreak();
             $this->_print('Enter the author\'s name:');
             $this->_lineBreak();
             $input['name'] = $this->listener->getInput();
-            $this->_print('------------------------------');
-            $this->_lineBreak();
             $this->_print('Enter the author\'s contact info (for example an email or URL):');
             $this->_lineBreak();
             $input['contact'] = $this->listener->getInput();
-            $this->_lineBreak();
-            // Prepare authro
+            // Prepare author
             $author = empty($input['name']) ? null : $input['name'];
             if ($author && !empty($input['contact']))
                 $author .= ' <'.$input['contact'].'>';
             if (array_key_exists('author', $this->config)) {
                 $current = $this->config['author'];
+                // Sanitize URLs for Regex replacement
+                if (strpos($current, '/') !== false)
+                    $current = str_replace('/','\/',$current);
                 // Replace in config file
                 $this->replaceInFile('author\'(|\s)=>(|\s)\''.$current.'\'', 'author\' => \''.$author.'\'', $this->configFilename);
                 $this->config = include $this->configFilename;


### PR DESCRIPTION
A few fixes after testing the Author update in #34 

1. Updated the SetCommand to support author. 
2. Cleanup output of Setup and Set Author commands. Avoid unneeded empty lines and group the author setup into one section between breaklines (------).
3. In Setup added line to output the added Author.
4. Update $this->config after setAuthor in Setup Command as the output of $this->config was outdated.
5. Prepare the author info before the preg_replace in case it contains a url with slashes. If you ran setup a second time after using a URL the ReplaceInFile would bomb with the following error and wipe out the contents of app.php leaving it empty. Error below;
Warning: preg_replace(): Unknown modifier '/' in /Users/garretthyder/GitHub/test101-wpmvc/vendor/10quality/wpmvc-commands/src/Base/BaseCommand.php on line 75
