### PR TITLE
Create Model during registration

### DIFF
--- a/src/RegisterCommand.php
+++ b/src/RegisterCommand.php
@@ -65,7 +65,7 @@ class RegisterCommand extends Command
                 // Prepare
                 $model = !isset($args[3]) || empty($args[3]) ? ucfirst($object[1]) : $args[3];
                 $controller = !isset($args[4]) || empty($args[4]) ? null : $args[4];
-                // Create controller
+                // Create model
                 $this->createModel($model);
                 // Set properties
                 $this->createModelProperty($model, 'type', $object[1]);
@@ -87,9 +87,13 @@ class RegisterCommand extends Command
             case 'model':
                 if (!isset($object[1]) || empty($object[1]))
                     throw new NoticeException('Command "'.$this->key.'": Expecting a model name.');
+                //Prepare
+                $model = ucfirst($object[1]);
+                // Create model
+                $this->createModel($model);
                 // Register model at bridge
                 $builder = Builder::parser($this->rootPath.'/app/Main.php');
-                $builder->addVisitor(new AddMethodCallVisitor($this->config, 'init', 'add_model', [$object[1]]));
+                $builder->addVisitor(new AddMethodCallVisitor($this->config, 'init', 'add_model', [$model]));
                 $builder->build();
                 // Print end
                 $this->_print('Model registered!');
@@ -98,7 +102,7 @@ class RegisterCommand extends Command
             case 'asset':
                 if (!isset($object[1]) || empty($object[1]))
                     throw new NoticeException('Command "'.$this->key.'": Expecting an asset relative path.');
-                // Register model at bridge
+                // Register asset at bridge
                 $builder = Builder::parser($this->rootPath.'/app/Main.php');
                 $builder->addVisitor(new AddMethodCallVisitor($this->config, 'init', 'add_asset', [$object[1]]));
                 $builder->build();


### PR DESCRIPTION
Hi @amostajo was wondering if the register command for Models should create them if they don't exist or at least indicate that they don't exist?

I noticed the register for type does create model, etc. And when I first used the register had expected it to create the Model or at least warn me it doesn't exist so I can manually create it.

Also in this PR just fixed two minor comments. 