### PR TITLE
Deprecate SetNameCommand in favour of SetCommand

### DIFF
--- a/src/SetCommand.php
+++ b/src/SetCommand.php
@@ -2,6 +2,7 @@
 
 namespace WPMVC\Commands;
 
+use WPMVC\Commands\Traits\SetNamespaceTrait;
 use WPMVC\Commands\Traits\SetVersionTrait;
 use WPMVC\Commands\Traits\SetTextDomainTrait;
 use WPMVC\Commands\Traits\SetAuthorTrait;
@@ -19,7 +20,7 @@ use Ayuco\Exceptions\NoticeException;
  */
 class SetCommand extends Command
 {
-    use SetVersionTrait, SetTextDomainTrait, SetAuthorTrait;
+    use SetNamespaceTrait, SetVersionTrait, SetTextDomainTrait, SetAuthorTrait;
 
     /**
      * Command key.
@@ -44,15 +45,21 @@ class SetCommand extends Command
     public function call($args = [])
     {
         if (count($args) == 0 || empty($args[2]))
-            throw new NoticeException('Command "'.$this->key.'": Expecting a setting (version|domain|author).');
+            throw new NoticeException('Command "'.$this->key.'": Expecting a setting (namespace|version|domain|author).');
 
         $object = explode(':', $args[2]);
 
         // Validations
-        if (!in_array($object[0], ['version','domain','author']))
-            throw new NoticeException('Command "'.$this->key.'": Invalid setting. Expecting (version|domain|author).');
+        if (!in_array($object[0], ['namespace','version','domain','author']))
+            throw new NoticeException('Command "'.$this->key.'": Invalid setting. Expecting (namespace|version|domain|author).');
 
         switch ($object[0]) {
+            case 'namespace':
+                // Validate second parameter
+                if ($object[0] === 'domain' && !isset($object[1]))
+                    throw new NoticeException('Command "'.$this->key.'": Expecting a namespace.');
+                $this->setNamespace($object[1]);
+                break;
             case 'version':
                 // Validate second parameter
                 if ($object[0] === 'version' && !isset($object[1]))

--- a/src/SetupCommand.php
+++ b/src/SetupCommand.php
@@ -13,7 +13,7 @@ use WPMVC\Commands\Traits\UpdateCommentTrait;
  * @copyright 10Quality <http://www.10quality.com>
  * @license MIT
  * @package WPMVC\Commands
- * @version 1.1.6
+ * @version 1.1.8
  */
 class SetupCommand extends Command
 {
@@ -35,18 +35,16 @@ class SetupCommand extends Command
     /**
      * Calls to command action.
      * @since 1.0.0
+     * @since 1.1.8 Replace 'setname' command with 'set name' command.
      *
      * @param array $args Action arguments.
      */
     public function call($args = [])
     {
-        $command = $this->listener->get('setname');
-        $setCommand = $this->listener->get('set');
+        $command = $this->listener->get('set');
         if (!$command)
-            throw new NoticeException('SetupCommand: "setname" command is not registered in ayuco.');
-        if (!$setCommand)
             throw new NoticeException('SetupCommand: "set" command is not registered in ayuco.');
-            
+
         try {
             $this->_print('------------------------------');
             $this->_lineBreak();
@@ -59,7 +57,7 @@ class SetupCommand extends Command
             $this->_lineBreak();
             $namespace = $this->listener->getInput();
             $namespace = empty($namespace) ? 'MyApp' : str_replace(' ', '', ucwords($namespace));
-            $command->setName($namespace);
+            $command->setNamespace($namespace);
             // TYPE
             $this->_print('------------------------------');
             $this->_lineBreak();
@@ -74,9 +72,9 @@ class SetupCommand extends Command
             $this->_lineBreak();
             $domain = $this->listener->getInput();
             $domain = empty($domain) ? 'my-app' : $domain;
-            $setCommand->setTextDomain(empty($domain) ? 'my-app' : $domain);
+            $command->setTextDomain(empty($domain) ? 'my-app' : $domain);
             // AUTHOR
-            $setCommand->setAuthor();
+            $command->setAuthor();
             $this->config = include $this->configFilename;
             // Update main
             $this->updateComment('author', $this->config['author'], $this->getMainClassPath());

--- a/src/Traits/SetNamespaceTrait.php
+++ b/src/Traits/SetNamespaceTrait.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace WPMVC\Commands\Traits;
+
+use Exception;
+use Ayuco\Exceptions\NoticeException;
+
+/**
+ * Trait used to set package namespace.
+ *
+ * @author Alejandro Mostajo <http://about.me/amostajo>
+ * @copyright 10Quality <http://www.10quality.com>
+ * @license MIT
+ * @package WPMVC\Commands
+ * @version 1.1.8
+ */
+trait SetNamespaceTrait
+{
+    /**
+     * Sets a projects namespace.
+     * @since 1.1.8
+     *
+     * @param string $namespace Package namespace.
+     */
+    public function setNamespace($namespace)
+    {
+        try {
+            // Check for MVC configuration file
+            if (empty($this->configFilename))
+                throw new NoticeException('Command "'.$this->key.'": No configuration file found.');
+
+            // Update Namespace in config file
+            $currentnamespace = $this->config['namespace'];
+            $this->replaceInFile($currentnamespace, $namespace, $this->configFilename);
+            $this->config = include $this->configFilename;
+
+            // Update Namespace in Main app file
+            if (file_exists($this->rootPath . '/app/Main.php'))
+            $this->replaceInFile( 
+                'namespace ' . $currentnamespace,
+                'namespace ' . $namespace,
+                $this->rootPath.'/app/Main.php'
+            );
+
+            // Update Namespace in Model files
+            foreach (scandir($this->rootPath.'/app/Models') as $filename) {
+                $this->replaceInFile( 
+                    'namespace ' . $currentnamespace,
+                    'namespace ' . $namespace,
+                    $this->rootPath.'/app/Models/' . $filename
+                );
+            }
+
+            // Update Namespace in Controller files
+            foreach (scandir($this->config['paths']['controllers']) as $filename) {
+                $this->replaceInFile( 
+                    'namespace ' . $currentnamespace,
+                    'namespace ' . $namespace,
+                    $this->config['paths']['controllers'] . $filename
+                );
+                $this->replaceInFile( 
+                    'use ' . $currentnamespace,
+                    'use ' . $namespace,
+                    $this->config['paths']['controllers'] . $filename
+                );
+            }
+
+            // Print end
+            $this->_print('Namespace updated!');
+            $this->_lineBreak();
+
+            // Dump Composer Autoload
+            if (file_exists($this->rootPath . '/composer.json'))
+                exec( 'composer dump-autoload' );
+        } catch (Exception $e) {
+            file_put_contents(
+                $this->rootPath.'/error_log',
+                $e->getMessage()
+            );
+            throw new NoticeException('Command "'.$this->key.'": Fatal error occurred.');
+        }
+    }
+}

--- a/tests/cases/SetNamespaceTest.php
+++ b/tests/cases/SetNamespaceTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Tests set namespace command.
+ *
+ * @author Alejandro Mostajo <http://about.me/amostajo>
+ * @copyright 10Quality <http://www.10quality.com>
+ * @license MIT
+ * @package WPMVC\Commands
+ * @version 1.1.0
+ */
+class SetNamespaceTest extends AyucoTestCase
+{
+    /**
+     * Test resulting message.
+     */
+    public function testResultMessage()
+    {
+        // Execute
+        $execution = exec('php '.WPMVC_AYUCO.' set namespace:PHPUnit');
+        // Assert
+        $this->assertEquals($execution, 'Namespace updated!');
+        // Teardown
+        exec('php '.WPMVC_AYUCO.' set namespace:MyApp');
+    }
+    /**
+     * Test Main app file updated.
+     */
+    public function testMainNamespaceValue()
+    {
+        // Prepare
+        $filename = FRAMEWORK_PATH.'/environment/app/Main.php';
+        // Execute
+        $execution = exec('php '.WPMVC_AYUCO.' set namespace:MainValue');
+        // Assert
+        $this->assertPregMatchContents('/namespace\sMainValue;/', $filename);
+        // Teardown
+        exec('php '.WPMVC_AYUCO.' set namespace:MyApp');
+    }
+}

--- a/tests/cases/SetupTest.php
+++ b/tests/cases/SetupTest.php
@@ -11,12 +11,12 @@
 class SetupTest extends AyucoTestCase
 {
     /**
-     * Tests missing setname command error.
+     * Tests missing set command error.
      */
     public function test()
     {
         $execution = exec('php '.WPMVC_AYUCO.' setup');
 
-        $this->assertEquals('SetupCommand: "setname" command is not registered in ayuco.', $execution);
+        $this->assertEquals('SetupCommand: "set" command is not registered in ayuco.', $execution);
     }
 }


### PR DESCRIPTION
Updates #28 to deprecate the SetName command in favour of the Set command.

@amostajo would love your review/feedback as this is a larger PR.

I'm not sure if we should expand on the basic SetNamespaceTest.php I created to cover the Model/Controller updates?

I did leave SetNameCommand.php but updated so it uses the SetCommand, I wasn't sure if we wanted to fully remove the command?

I also left `SetNameCommand` defined in the `use` statement of the tests > environment > ayuco file, figured you'd replace that with another ayuco.

Also I wasn't sure the appropriate approach to updating the ayuco executable for this type of change as SetName is baked in here - https://github.com/10quality/ayuco