### PR TITLE
Indicate SetNameCommand is deprecated

### DIFF
--- a/src/SetNameCommand.php
+++ b/src/SetNameCommand.php
@@ -28,7 +28,7 @@ class SetNameCommand extends Command
      * @since 1.0.0
      * @var string
      */
-    protected $description = 'Changes project\'s namespace. Expects name as parameter.';
+    protected $description = 'DEPRECATED. This command will no longer be maintained; use the "set" command instead.';
 
     /**
      * Calls to command action.

--- a/src/SetNameCommand.php
+++ b/src/SetNameCommand.php
@@ -26,9 +26,10 @@ class SetNameCommand extends Command
     /**
      * Command description.
      * @since 1.0.0
+     * @since 1.1.8 Indicate "setname" command is deprecated and replaced by "set" command.
      * @var string
      */
-    protected $description = 'DEPRECATED. This command will no longer be maintained; use the "set" command instead.';
+    protected $description = 'DEPRECATED. The "setname" command will no longer be maintained; use the "set" command instead.';
 
     /**
      * Calls to command action.


### PR DESCRIPTION
Related to #28

@amostajo Do you feel after the deprecation message we should keep the original description?
"Changes project's namespace. Expects name as parameter."