### PR TITLE
Handle version replace as full string

### DIFF
--- a/src/Traits/SetVersionTrait.php
+++ b/src/Traits/SetVersionTrait.php
@@ -28,7 +28,7 @@ trait SetVersionTrait
             // Prepare
             $currentVersion = $this->config['version'];
             // Replace in config file
-            $this->replaceInFile($currentVersion, $version, $this->configFilename);
+            $this->replaceInFile("'".$currentVersion."'", "'".$version."'", $this->configFilename);
             $this->config = include $this->configFilename;
             // Replace in package.json
             $packageJson = json_decode(file_get_contents($this->rootPath.'/package.json'));

--- a/src/Traits/SetVersionTrait.php
+++ b/src/Traits/SetVersionTrait.php
@@ -28,7 +28,7 @@ trait SetVersionTrait
             // Prepare
             $currentVersion = $this->config['version'];
             // Replace in config file
-            $this->replaceInFile("'".$currentVersion."'", "'".$version."'", $this->configFilename);
+            $this->replaceInFile('\''.$currentVersion.'\'', '\''.$version.'\'', $this->configFilename);
             $this->config = include $this->configFilename;
             // Replace in package.json
             $packageJson = json_decode(file_get_contents($this->rootPath.'/package.json'));


### PR DESCRIPTION
Handle version replace to include wrapping quotes to ensure the IP isn't updated when version is updated from 0.0.1 to anything else. Fixes #70