### PR TITLE
Upgrade some WPPrinter methods to protected

### DIFF
--- a/src/Parser/WPPrinter.php
+++ b/src/Parser/WPPrinter.php
@@ -562,7 +562,7 @@ class WPPrinter extends Printer
      * 
      * @see \PhpParser\PrettyPrinter\Standard@hasNodeWithComments
      */
-    private function hasNodeWithComments(array $nodes)
+    protected function hasNodeWithComments(array $nodes)
     {
         foreach ($nodes as $node) {
             if ($node && $node->getComments()) {
@@ -577,7 +577,7 @@ class WPPrinter extends Printer
      * 
      * @see \PhpParser\PrettyPrinter\Standard@pMaybeMultiline
      */
-    private function pMaybeMultiline(array $nodes, $trailingComma = false)
+    protected function pMaybeMultiline(array $nodes, $trailingComma = false)
     {
         if (!$this->hasReachedLineLength($nodes) && !$this->hasNodeWithComments($nodes)) {
             return $this->pCommaSeparated($nodes);


### PR DESCRIPTION
When running `php ayuco add`, the following errors were getting thrown for me:

>PHP Fatal error:  Access level to WPMVC\Commands\Parser\WPPrinter::hasNodeWithComments() must be protected (as in class PhpParser\PrettyPrinter\Standard) or weaker in /srv/www/wordpress-mvc/public_html/wp-content/plugins/my-plugin/vendor/10quality/wpmvc-commands/src/Parser/WPPrinter.php on line 25


and 

>PHP Fatal error:  Access level to WPMVC\Commands\Parser\WPPrinter::pMaybeMultiline() must be protected (as in class PhpParser\PrettyPrinter\Standard) or weaker in /srv/www/wordpress-mvc/public_html/wp-content/plugins/my-project/vendor/10quality/wpmvc-commands/src/Parser/WPPrinter.php on line 25


I updated the methods to protected in my project and now they work as expected.

Looks like the PHP-Parser dependency updated the parent methods to protected a couple months ago in https://github.com/nikic/PHP-Parser/commit/1d1bc8a36459d67acef508b952dad097960b110e#diff-d9d234fe7bea15ea81db29f63acb50bfe9c8e09bbb3ff7267bb319945fb8fc01